### PR TITLE
Allow to compare Mutez values

### DIFF
--- a/tezos-core/src/types/mutez.rs
+++ b/tezos-core/src/types/mutez.rs
@@ -6,7 +6,7 @@ use derive_more;
 use derive_more::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Display, Div,
     DivAssign, Mul, MulAssign, Not, Octal, Product, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
-    Sub, SubAssign, Sum,
+    Sub, SubAssign, Sum
 };
 use lazy_static::lazy_static;
 use num_bigint::BigUint;
@@ -41,6 +41,7 @@ lazy_static! {
     Add,
     AddAssign,
     PartialEq,
+    PartialOrd,
     Debug,
     Eq,
     Clone,
@@ -343,6 +344,16 @@ mod test {
         let v2: Mutez = 2u8.into();
 
         assert_eq!(v1 + v2, 3u32.into());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cmp() -> Result<()> {
+        let v1: Mutez = 1u8.into();
+        let v2: Mutez = 2u8.into();
+
+        assert!(v1 < v2);
 
         Ok(())
     }

--- a/tezos-core/src/types/mutez.rs
+++ b/tezos-core/src/types/mutez.rs
@@ -6,7 +6,7 @@ use derive_more;
 use derive_more::{
     Add, AddAssign, BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Display, Div,
     DivAssign, Mul, MulAssign, Not, Octal, Product, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
-    Sub, SubAssign, Sum
+    Sub, SubAssign, Sum,
 };
 use lazy_static::lazy_static;
 use num_bigint::BigUint;


### PR DESCRIPTION
Hey guys, a small improvement for the `Mutez` type that enables partial ordering.
It is a nice feature to have, e.g. in my case I needed to compare transaction amount + fees against the source account balance.