### PR TITLE
chrono: disable default features (std only), fix deprecated call

### DIFF
--- a/tezos-michelson/Cargo.toml
+++ b/tezos-michelson/Cargo.toml
@@ -12,7 +12,7 @@ num-integer = "0.1"
 regex = "1"
 hex = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["std"], default-features = false }
 lazy_static = "1"
 
 tezos-core = { path = "../tezos-core", version = "0.1.3" }

--- a/tezos-michelson/src/internal/packer.rs
+++ b/tezos-michelson/src/internal/packer.rs
@@ -753,7 +753,7 @@ impl MichelinePacker {
                 let ts_secs = value / 1000;
                 let ts_ns = (value % 1000) * 1_000_000;
                 let dt = DateTime::<Utc>::from_utc(
-                    NaiveDateTime::from_timestamp(ts_secs, ts_ns as u32),
+                    NaiveDateTime::from_timestamp_opt(ts_secs, ts_ns as u32).unwrap(),
                     Utc,
                 );
                 Ok(

--- a/tezos-operation/Cargo.toml
+++ b/tezos-operation/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.3"
 edition = "2021"
 
 [dependencies]
-chrono = "0.4"
+chrono = { version= "0.4", default-features = false, features = ["clock", "std"] }
 derive_more = "0.99.17"
 num-traits = "0.2"
 num-derive = "0.3"

--- a/tezos-operation/src/internal/coder/operation_content_bytes_coder.rs
+++ b/tezos-operation/src/internal/coder/operation_content_bytes_coder.rs
@@ -603,7 +603,7 @@ impl ConsumingDecoder<BlockHeader, u8, Error> for OperationContentBytesCoder {
 
         let ts_secs = timestamp_millis / 1000;
         let ts_ns = (timestamp_millis % 1000) * 1_000_000;
-        let timestamp = NaiveDateTime::from_timestamp(ts_secs, ts_ns as u32);
+        let timestamp = NaiveDateTime::from_timestamp_opt(ts_secs, ts_ns as u32).unwrap();
 
         let validation_pass = value.consume_first()?;
         let operations_hash = OperationListListHash::from_consumable_bytes(value)?;

--- a/tezos-rpc/Cargo.toml
+++ b/tezos-rpc/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 reqwest = { version = "0.11", features = ["json"], optional = true }
 derive_more = "0.99"
 num-bigint =  { version = "0.4.3", features = ["serde"] }
-chrono = { version = "0.4",  features = ["serde"] }
+chrono = { version = "0.4",  features = ["serde", "std"], default-features = false }
 async-trait = "0.1"
 
 # Local dependencies


### PR DESCRIPTION
`chrono` crate enables `wasmbindgen` and `clock` features by default which leads to import errors when trying to compile for wasm32-unknown-unknown because it treats it as browser target which is not always the case.
In this PR default features are disabled and explicitly specified instead.
Also, a deprecated chrono call is fixed.