### PR TITLE
Fix Michelson instructions and add new ones

### DIFF
--- a/tezos-contract/src/contract.rs
+++ b/tezos-contract/src/contract.rs
@@ -363,7 +363,7 @@ impl CompatibleWith<Type> for DataSequence {
                 let element_type = &value.r#type;
                 self.values()
                     .iter()
-                    .all(|item| item.is_compatible_with(&element_type.clone().into()))
+                    .all(|item| item.is_compatible_with(&element_type))
             }
             Type::Pair(_) => {
                 let pair: Data = Pair::new(self.clone().into_values()).into();

--- a/tezos-michelson/src/internal/normalizer.rs
+++ b/tezos-michelson/src/internal/normalizer.rs
@@ -123,7 +123,7 @@ impl Normalizer<Type> for MichelsonNormalizer {
                 types::List::new(Self::normalize(*value.r#type), Some(value.metadata)).into()
             }
             Type::Set(value) => {
-                types::Set::new(Self::normalize(value.r#type), Some(value.metadata)).into()
+                types::Set::new(Self::normalize(*value.r#type), Some(value.metadata)).into()
             }
             Type::Contract(value) => {
                 types::Contract::new(Self::normalize(*value.r#type), Some(value.metadata)).into()
@@ -269,7 +269,7 @@ impl Normalizer<Instruction> for MichelsonNormalizer {
             }
             Instruction::Loop(value) => instructions::Loop::new(Self::normalize(value.body)).into(),
             Instruction::Dip(value) => {
-                instructions::Dip::new(Self::normalize(value.instruction), value.n).into()
+                instructions::Dip::new(value.n, Self::normalize(value.instruction)).into()
             }
             Instruction::EmptyBigMap(value) => instructions::EmptyBigMap::new(
                 Self::normalize(value.key_type),

--- a/tezos-michelson/src/internal/packer.rs
+++ b/tezos-michelson/src/internal/packer.rs
@@ -1150,8 +1150,8 @@ mod test {
             (
                 &hex!("050200000009051f0200000002034f"),
                 vec![data::instructions::dip(
-                    vec![data::instructions::unit()].into(),
                     None,
+                    vec![data::instructions::unit()].into(),
                 )]
                 .into(),
                 Some(types::lambda(types::unit(), types::unit())),

--- a/tezos-michelson/src/michelson/data/instructions.rs
+++ b/tezos-michelson/src/michelson/data/instructions.rs
@@ -8,7 +8,7 @@ make_instructions!(
     (Swap, SWAP, swap, 76),
     (GetAndUpdate, GET_AND_UPDATE, get_and_update, 140),
     (Apply, APPLY, apply, 115),
-    (FailWith, FAIL_WITH, fail_with, 39),
+    (FailWith, FAILWITH, failwith, 39),
     (
         Rename,
         RENAME,
@@ -28,7 +28,8 @@ make_instructions!(
         CAST,
         cast,
         87,
-        metadata_type: crate::michelson::metadata::VariableMetadata
+        metadata_type: crate::michelson::metadata::VariableMetadata,
+        (r#type: crate::michelson::types::Type)
     ),
     (
         Cdr,
@@ -118,7 +119,14 @@ make_instructions!(
     ),
     (Slice, SLICE, slice, 111),
     (Pack, PACK, pack, 12),
-    (Unpack, UNPACK, unpack, 13),
+    (
+        Unpack,
+        UNPACK,
+        unpack,
+        13,
+        metadata_type: crate::michelson::metadata::TypeVariableMetadata,
+        (r#type: crate::michelson::types::Type)
+    ),
     (
         Add,
         ADD,
@@ -299,6 +307,13 @@ make_instructions!(
         metadata_type: crate::michelson::metadata::VariableMetadata
     ),
     (
+        SubMutez,
+        SUB_MUTEZ,
+        sub_mutez,
+        147,
+        metadata_type: crate::michelson::metadata::VariableMetadata
+    ),
+    (
         Mul,
         MUL,
         mul,
@@ -436,7 +451,7 @@ make_instructions!(
         SELF,
         self_,
         73,
-        metadata_type: crate::michelson::metadata::VariableMetadata
+        metadata_type: crate::michelson::metadata::FieldMetadata
     ),
     (
         SelfAddress,
@@ -450,7 +465,7 @@ make_instructions!(
         CONTRACT,
         contract,
         85,
-        metadata_type: crate::michelson::metadata::VariableMetadata,
+        metadata_type: crate::michelson::metadata::FieldMetadata,
         (r#type: crate::michelson::types::Type)
     ),
     (TransferTokens, TRANSFER_TOKENS, transfer_tokens, 77),

--- a/tezos-michelson/src/michelson/metadata.rs
+++ b/tezos-michelson/src/michelson/metadata.rs
@@ -2,6 +2,57 @@ use super::annotations::{Annotation, Kind};
 use crate::{micheline::primitive_application::PrimitiveApplication, Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
+pub struct FieldMetadata {
+    field_name: Option<Annotation>,
+}
+
+impl FieldMetadata {
+    pub fn field_name(&self) -> &Option<Annotation> {
+        &self.field_name
+    }
+
+    pub fn annotations(&self) -> Vec<&Annotation> {
+        vec![self.field_name()]
+            .into_iter()
+            .flat_map(|annot| annot)
+            .collect::<Vec<&Annotation>>()
+    }
+
+    pub fn new(field_name: Option<Annotation>) -> Result<Self> {
+        if let Some(field_name) = &field_name {
+            if !Self::is_valid_field_name(&field_name) {
+                return Err(Error::InvalidAnnotation);
+            }
+        }
+        Ok(Self { field_name })
+    }
+
+    pub fn with_field_name(mut self, name: String) -> Self {
+        self.field_name = Some(Annotation::new_with_kind(Kind::Field, name));
+
+        self
+    }
+
+    fn is_valid_field_name(annotation: &Annotation) -> bool {
+        annotation.kind() == Kind::Field
+    }
+}
+
+impl Default for FieldMetadata {
+    fn default() -> Self {
+        Self { field_name: None }
+    }
+}
+
+impl TryFrom<&PrimitiveApplication> for FieldMetadata {
+    type Error = Error;
+
+    fn try_from(value: &PrimitiveApplication) -> Result<Self> {
+        Self::new(value.first_annot(Kind::Field)?)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeFieldMetadata {
     type_name: Option<Annotation>,
     field_name: Option<Annotation>,

--- a/tezos-michelson/src/michelson/types.rs
+++ b/tezos-michelson/src/michelson/types.rs
@@ -38,12 +38,7 @@ make_types!(
     ),
     (Option, option, 99, boxed: (r#type: Type)),
     (List, list, 95, boxed: (r#type: Type)),
-    (
-        Set,
-        set,
-        102,
-        (r#type: crate::michelson::types::comparables::Type)
-    ),
+    (Set, set, 102, boxed: (r#type: Type)),
     (Operation, operation, 109),
     (Contract, contract, 90, boxed: (r#type: Type)),
     (Ticket, ticket, 135, boxed: (r#type: Type)),
@@ -56,7 +51,13 @@ make_types!(
         boxed: (parameter_type: Type),
         boxed: (return_type: Type)
     ),
-    (Map, map, 96, boxed: (key_type: Type), boxed: (value_type: Type)),
+    (
+        Map,
+        map,
+        96,
+        boxed: (key_type: Type),
+        boxed: (value_type: Type)
+    ),
     (
         BigMap,
         big_map,


### PR DESCRIPTION
Here are some changes made in order to comply with the latest language spec:
- `DIP n` <= optional nat argument comes first
- `FAILWITH` <= typo
- `UNPACK` additionally expects type argument
- `CAST` instruction also expects type argument (it's kinda deprecated, but still used in some tests)
- `SUB_MUTEZ` instruction added
- `SELF` and `CONTRACT` can have field annotation (entrypoint)
- `set` type argument is generalized to `Type` — while `set`, `ticket`, and `map` keys can only be comparable, current Michelson parser does not automatically converts comparable pairs, "or"s, and options into their "comparable twins", thus there can be an ambiguous situation.