### PR TITLE
fix stack overflow when converting an address

### DIFF
--- a/tezos-core/src/types/encoded.rs
+++ b/tezos-core/src/types/encoded.rs
@@ -773,4 +773,23 @@ make_encoded_structs!(
             ],
         }
     },
+    {
+        use {
+            internal::coder::EncodedBytesCoder,
+        }
+        struct smart_rollup_address::SmartRollupAddress;
+        coder: EncodedBytesCoder;
+        meta {
+            base58_prefix: "sr1",
+            base58_length: 36,
+            bytes_prefix: [6, 124, 117,],
+            bytes_length: 20,
+        }
+        test {
+            string_value: "sr1AqF5LDHZKeVyeNTCXueErVDi1S61PzTRD",
+            bytes_value: [
+                52, 142, 195, 75, 199, 253, 40, 202, 117, 54, 126, 155, 18, 69, 127, 11,31, 31, 206, 127,
+            ],
+        }
+    },
 );

--- a/tezos-core/src/types/encoded/address.rs
+++ b/tezos-core/src/types/encoded/address.rs
@@ -59,7 +59,7 @@ impl From<Address> for String {
     fn from(value: Address) -> Self {
         match value {
             Address::Implicit(value) => value.into(),
-            Address::Originated(_) => value.into(),
+            Address::Originated(value) => value.into(),
         }
     }
 }
@@ -444,6 +444,16 @@ mod test {
             return Ok(());
         }
         Err(Error::InvalidConversion)
+    }
+
+    #[test]
+    fn test_kt1_address_to_string() -> Result<()> {
+        let address: Address = "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo".try_into()?;
+        assert_eq!(
+            String::from(address),
+            "KT1QTcAXeefhJ3iXLurRt81WRKdv7YqyYFmo"
+        );
+        return Ok(());
     }
 
     #[test]


### PR DESCRIPTION
Hey!

I found a stack overflow using `String::from(address)` with a contract address.