### PR TITLE
no_std support: replace regex with manual validation, std with core/alloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base64"
@@ -425,9 +425,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc906908ea6458456e5eaa160a9c08543ec3d1e6f71e2235cedd660cb65f9df0"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -615,14 +615,14 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.2"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644d3b8674a5fc5b929ae435bca85c2323d85ccb013a5509c2ac9ee11a6284ba"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "signature",
+ "signature 2.0.0",
 ]
 
 [[package]]
@@ -656,12 +656,13 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea5a92946e8614bb585254898bb7dd1ddad241ace60c52149e3765e34cc039d"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
+ "der",
  "digest 0.10.6",
  "ff",
  "generic-array",
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -833,7 +834,6 @@ checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -1156,16 +1156,14 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
  "sha2 0.10.6",
- "signature",
 ]
 
 [[package]]
@@ -1437,13 +1435,12 @@ dependencies = [
 
 [[package]]
 name = "p256"
-version = "0.13.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7270da3e5caa82afd3deb054cc237905853813aea3859544bc082c3fe55b8d47"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
- "primeorder",
  "sha2 0.10.6",
 ]
 
@@ -1541,9 +1538,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d2820d87d2b008616e5c27212dd9e0e694fb4c6b522de06094106813328cb49"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
@@ -1580,15 +1577,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "primeorder"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7613fdcc0831c10060fa69833ea8fa2caa94b6456f51e25356a885b530a2e3d0"
-dependencies = [
- "elliptic-curve",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -1743,12 +1731,13 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
+ "crypto-bigint",
  "hmac",
- "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1795,9 +1784,9 @@ checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "sec1"
-version = "0.7.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48518a2b5775ba8ca5b46596aae011caa431e6ce7e4a67ead66d92f08884220e"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
  "der",
@@ -1935,13 +1924,19 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.0.0"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.6",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 
 [[package]]
 name = "similar"
@@ -1993,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0445c905640145c7ea8c1993555957f65e7c46d0535b91ba501bc9bfc85522f"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,12 +2102,10 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "k256",
- "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits",
  "p256",
- "regex",
  "serde",
 ]
 
@@ -2119,10 +2117,8 @@ dependencies = [
  "derive_more",
  "hex",
  "hex-literal",
- "lazy_static",
  "num-integer",
  "num-traits",
- "regex",
  "serde",
  "serde_json",
  "tezos-core",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ Rust 1.60.0 or above.
 
 Install the `rustc` compiler and the `cargo` command line tool through [rustup](https://rustup.rs).
 
+### Support for no_std
+
+The `tezos-core` and `tezos-michelson` crates can be used without the standard library (`#![no_std]`) by disabling
+the default `std` feature in your `Cargo.toml`:
+
+```toml
+tezos-core = { git = "https://github.com/airgap-it/tezos-rust-sdk", default-features = false }
+tezos-michelson = { git = "https://github.com/airgap-it/tezos-rust-sdk", default-features = false }
+```
+
 ## Build
 
 ```shell

--- a/tezos-contract/Cargo.toml
+++ b/tezos-contract/Cargo.toml
@@ -10,10 +10,10 @@ derive_more = "0.99.17"
 async-trait = "0.1"
 
 # Local dependencies
-tezos-core = { path = "../tezos-core" }
-tezos-rpc = { path = "../tezos-rpc", default-features = false }
-tezos-michelson = { path = "../tezos-michelson" }
-tezos-operation = { path = "../tezos-operation" }
+tezos-core = { path = "../tezos-core", version = "0.1.4" }
+tezos-rpc = { path = "../tezos-rpc", version = "0.1.4", default-features = false }
+tezos-michelson = { path = "../tezos-michelson", version = "0.1.4" }
+tezos-operation = { path = "../tezos-operation", version = "0.1.4" }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["macros"] }

--- a/tezos-contract/Cargo.toml
+++ b/tezos-contract/Cargo.toml
@@ -10,10 +10,10 @@ derive_more = "0.99.17"
 async-trait = "0.1"
 
 # Local dependencies
-tezos-core = { path = "../tezos-core", version = "0.1.4" }
-tezos-rpc = { path = "../tezos-rpc", version = "0.1.4", default-features = false }
-tezos-michelson = { path = "../tezos-michelson", version = "0.1.4" }
-tezos-operation = { path = "../tezos-operation", version = "0.1.4" }
+tezos-core = { path = "../tezos-core" }
+tezos-rpc = { path = "../tezos-rpc", default-features = false }
+tezos-michelson = { path = "../tezos-michelson" }
+tezos-operation = { path = "../tezos-operation" }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["macros"] }

--- a/tezos-contract/src/error.rs
+++ b/tezos-contract/src/error.rs
@@ -1,8 +1,11 @@
 use std::result;
 
-use derive_more::{Display, Error as DError, From};
+#[cfg(feature = "std")]
+use derive_more::Error as DError;
+use derive_more::{Display, From};
 
-#[derive(DError, Display, Debug, From)]
+#[derive(Display, Debug, From)]
+#[cfg_attr(feature = "std", derive(DError))]
 pub enum Error {
     Internal {
         description: String,

--- a/tezos-contract/src/error.rs
+++ b/tezos-contract/src/error.rs
@@ -1,4 +1,4 @@
-use std::result;
+use core::result;
 
 #[cfg(feature = "std")]
 use derive_more::Error as DError;

--- a/tezos-core/Cargo.toml
+++ b/tezos-core/Cargo.toml
@@ -7,19 +7,24 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99.17"
-bs58 = { version = "0.4", features = ["check"] }
-num-bigint = "0.4"
-num-integer = "0.1"
-num-traits = { version = "0.2", features = ["i128"] }
+bs58 = { version = "0.4", features = ["check", "alloc"], default-features = false }
+num-bigint = { version = "0.4", default-features = false }
+num-integer = { version = "0.1", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 ed25519-dalek = { version = "1.0.1", optional = true }
-k256 = { version = "0.13", optional = true, features = ["ecdsa"] }
-p256 = { version = "0.13", optional = true, features = ["ecdsa"] }
-hex = "0.4"
+k256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256"] }
+p256 = { version = "0.11", optional = true, features = ["ecdsa", "sha256"] }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", features = ["derive"], optional = true }
-blake2 = "0.10"
+blake2 = { version = "0.10", default-features = false }
 cfg-if = "1"
 
 [features]
+default = ["std"]
+std = [
+	"bs58/std",
+	"blake2/std"
+]
 full_crypto = ["ed25519", "secp256_k1", "p256"]
 ed25519 = ["dep:ed25519-dalek"]
 secp256_k1 = ["dep:k256"]

--- a/tezos-core/Cargo.toml
+++ b/tezos-core/Cargo.toml
@@ -11,12 +11,10 @@ bs58 = { version = "0.4", features = ["check"] }
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = { version = "0.2", features = ["i128"] }
-regex = "1"
 ed25519-dalek = { version = "1.0.1", optional = true }
 k256 = { version = "0.13", optional = true, features = ["ecdsa"] }
 p256 = { version = "0.13", optional = true, features = ["ecdsa"] }
 hex = "0.4"
-lazy_static = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 blake2 = "0.10"
 cfg-if = "1"

--- a/tezos-core/src/crypto.rs
+++ b/tezos-core/src/crypto.rs
@@ -3,6 +3,7 @@
 pub mod default;
 
 use crate::Result;
+use alloc::vec::Vec;
 
 /// Trait defining the interface of a crypto provider.
 pub trait CryptoProvider {

--- a/tezos-core/src/error.rs
+++ b/tezos-core/src/error.rs
@@ -1,8 +1,12 @@
-use derive_more::{Display, Error as DError, From};
+use derive_more::{Display, From};
 use std::{result, string::FromUtf8Error};
 
+#[cfg(feature = "std")]
+use derive_more::Error as DError;
+
 /// Errors returned by this crate.
-#[derive(DError, Display, Debug, From)]
+#[derive(Display, Debug, From)]
+#[cfg_attr(feature = "std", derive(DError))]
 pub enum Error {
     Internal {
         description: String,

--- a/tezos-core/src/error.rs
+++ b/tezos-core/src/error.rs
@@ -1,5 +1,8 @@
+use alloc::string::FromUtf8Error;
+use alloc::string::String;
+use core::num;
+use core::result;
 use derive_more::{Display, From};
-use std::{result, string::FromUtf8Error};
 
 #[cfg(feature = "std")]
 use derive_more::Error as DError;
@@ -23,10 +26,11 @@ pub enum Error {
     InvalidUnsignedIntegerString,
     InvalidTezString,
     BigIntParse {
+        #[cfg_attr(feature = "std", error(not(source)))]
         source: num_bigint::ParseBigIntError,
     },
     IntParse {
-        source: std::num::ParseIntError,
+        source: num::ParseIntError,
     },
     InvalidStringConversion {
         source: FromUtf8Error,
@@ -36,12 +40,14 @@ pub enum Error {
     InvalidNaturalBytes,
     InvalidIntegerBytes,
     TryFromInt {
-        source: std::num::TryFromIntError,
+        source: num::TryFromIntError,
     },
     TryFromBigInt {
+        #[cfg_attr(feature = "std", error(not(source)))]
         source: num_bigint::TryFromBigIntError<num_bigint::BigInt>,
     },
     TryFromBigUInt {
+        #[cfg_attr(feature = "std", error(not(source)))]
         source: num_bigint::TryFromBigIntError<num_bigint::BigUint>,
     },
     Blake2InvalidOutputSize {

--- a/tezos-core/src/internal/coder.rs
+++ b/tezos-core/src/internal/coder.rs
@@ -18,11 +18,11 @@ pub use self::{
 use super::consumable_list::ConsumableList;
 
 pub trait ConfigurableEncoder<T, S, C, Error> {
-    fn encode_with_configuration(value: &T, configuration: C) -> std::result::Result<S, Error>;
+    fn encode_with_configuration(value: &T, configuration: C) -> core::result::Result<S, Error>;
 }
 
 pub trait Encoder<T, S, Error>: ConfigurableEncoder<T, S, (), Error> {
-    fn encode(value: &T) -> std::result::Result<S, Error>;
+    fn encode(value: &T) -> core::result::Result<S, Error>;
 }
 
 impl<E, T, S, Error> ConfigurableEncoder<T, S, (), Error> for E

--- a/tezos-core/src/internal/coder/encoded/address_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/address_bytes_coder.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use core::ops::Add;
 
 use crate::{
     internal::{
@@ -12,6 +12,7 @@ use crate::{
     types::encoded::Address,
     Error, Result,
 };
+use alloc::vec::Vec;
 
 use super::contract_address_bytes_coder::ContractAddressBytesCoder;
 

--- a/tezos-core/src/internal/coder/encoded/contract_address_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/contract_address_bytes_coder.rs
@@ -6,6 +6,8 @@ use crate::{
     types::encoded::{ContractAddress, ContractHash, Encoded, TraitMetaEncoded},
     Error, Result,
 };
+use alloc::string::String;
+use alloc::vec::Vec;
 
 pub struct ContractAddressBytesCoder;
 

--- a/tezos-core/src/internal/coder/encoded/encoded_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/encoded_bytes_coder.rs
@@ -4,6 +4,7 @@ use crate::internal::{
 };
 use crate::types::encoded::{Encoded, MetaEncoded};
 use crate::{Error, Result};
+use alloc::vec::Vec;
 
 pub struct EncodedBytesCoder;
 

--- a/tezos-core/src/internal/coder/encoded/encoded_group_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/encoded_group_bytes_coder.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use crate::{
     internal::{
@@ -9,6 +9,7 @@ use crate::{
     types::encoded::Encoded,
     Error, Result,
 };
+use alloc::vec::Vec;
 
 use super::encoded_bytes_coder::EncodedBytesCoder;
 

--- a/tezos-core/src/internal/coder/encoded/implicit_address_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/implicit_address_bytes_coder.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use core::ops::Add;
 
 use crate::{
     internal::{
@@ -12,6 +12,7 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::vec::Vec;
 
 use super::encoded_group_bytes_coder::{EncodedGroupBytesCoder, TagProvider};
 

--- a/tezos-core/src/internal/coder/encoded/public_key_bytes_coder.rs
+++ b/tezos-core/src/internal/coder/encoded/public_key_bytes_coder.rs
@@ -1,4 +1,4 @@
-use std::ops::Add;
+use core::ops::Add;
 
 use crate::{
     internal::{
@@ -15,6 +15,7 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::vec::Vec;
 
 pub struct PublicKeyBytesCoder;
 

--- a/tezos-core/src/internal/coder/mutez.rs
+++ b/tezos-core/src/internal/coder/mutez.rs
@@ -1,10 +1,10 @@
+use super::{number::natural::NaturalBytesCoder, ConsumingDecoder, Decoder, Encoder};
 use crate::{
     internal::consumable_list::ConsumableList,
     types::{mutez::Mutez, number::Nat},
     Error, Result,
 };
-
-use super::{number::natural::NaturalBytesCoder, ConsumingDecoder, Decoder, Encoder};
+use alloc::vec::Vec;
 
 pub struct MutezBytesCoder;
 

--- a/tezos-core/src/internal/coder/number/integer.rs
+++ b/tezos-core/src/internal/coder/number/integer.rs
@@ -1,6 +1,7 @@
 use num_bigint::{BigInt, BigUint, ToBigUint};
 use num_traits::{Signed, ToPrimitive, Zero};
 
+use super::natural::NaturalBytesCoder;
 use crate::{
     internal::{
         coder::{ConsumingDecoder, Decoder, Encoder},
@@ -9,8 +10,7 @@ use crate::{
     types::number::Int,
     Error, Result,
 };
-
-use super::natural::NaturalBytesCoder;
+use alloc::{vec, vec::Vec};
 
 pub struct IntegerBytesCoder;
 

--- a/tezos-core/src/internal/coder/number/natural.rs
+++ b/tezos-core/src/internal/coder/number/natural.rs
@@ -9,6 +9,7 @@ use crate::{
     types::number::Nat,
     Error, Result,
 };
+use alloc::{vec, vec::Vec};
 
 #[derive(Debug)]
 pub struct NaturalBytesCoder;

--- a/tezos-core/src/internal/consumable_list.rs
+++ b/tezos-core/src/internal/consumable_list.rs
@@ -1,4 +1,4 @@
-use std::ops::Range;
+use core::ops::Range;
 
 use crate::{Error, Result};
 

--- a/tezos-core/src/internal/crypto.rs
+++ b/tezos-core/src/internal/crypto.rs
@@ -1,5 +1,7 @@
 use crate::crypto::CryptoProvider;
 use crate::{Error, Result};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 pub struct Crypto {
     ed25519_provider: Option<Box<dyn CryptoProvider>>,

--- a/tezos-core/src/internal/types.rs
+++ b/tezos-core/src/internal/types.rs
@@ -1,4 +1,5 @@
 use crate::types::encoded::{Encoded, MetaEncoded};
+use alloc::vec::Vec;
 
 pub trait BytesTag {
     fn value(&self) -> &'static [u8];

--- a/tezos-core/src/internal/utils.rs
+++ b/tezos-core/src/internal/utils.rs
@@ -1,7 +1,9 @@
 use crate::{internal::consumable_list::ConsumableList, types::encoded::Encoded};
-use num_traits::ToPrimitive;
-
 use crate::{Error, Result};
+use alloc::borrow::ToOwned;
+use alloc::string::String;
+use alloc::vec::Vec;
+use num_traits::ToPrimitive;
 
 use super::{coder::ConsumingDecoder, consumable_list::ConsumableBytes};
 

--- a/tezos-core/src/lib.rs
+++ b/tezos-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! The `tezos-core` crate defines many common types and basic crypto primitives used by
 //! the `tezos-michelson`, `tezos-operation`, `tezos-rpc` and `tezos-contract` crates.
@@ -122,6 +122,7 @@
 //! let chain_id = ChainId::new("NetXPduhFKtb9SG".into()).unwrap();
 //! let ed25519_public_key = Ed25519PublicKey::new("edpktmJqEE79FtfdWse1gqnUey1vNBkB3zNV99Pi95SRAs8NMatczG".into());
 //! ```
+extern crate alloc;
 
 pub mod crypto;
 mod error;
@@ -142,6 +143,7 @@ pub use crate::{
     crypto::CryptoProvider,
     error::{Error, Result},
 };
+use alloc::boxed::Box;
 
 /// A structure used to provide configurations to other tezos crates.
 ///

--- a/tezos-core/src/lib.rs
+++ b/tezos-core/src/lib.rs
@@ -127,6 +127,7 @@ pub mod crypto;
 mod error;
 pub mod internal;
 pub mod types;
+pub mod validation;
 
 use cfg_if::cfg_if;
 

--- a/tezos-core/src/types/encoded.rs
+++ b/tezos-core/src/types/encoded.rs
@@ -20,6 +20,8 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::string::String;
+use alloc::vec::Vec;
 
 use macros::{make_encoded_struct, make_encoded_structs};
 

--- a/tezos-core/src/types/encoded/address.rs
+++ b/tezos-core/src/types/encoded/address.rs
@@ -10,6 +10,10 @@ use crate::{
     internal::coder::{AddressBytesCoder, ContractAddressBytesCoder, ImplicitAddressBytesCoder},
     Error, Result,
 };
+use alloc::format;
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 /// Group of base58 encoded Tezos account addresses, either implicit or originated.
 ///

--- a/tezos-core/src/types/encoded/key.rs
+++ b/tezos-core/src/types/encoded/key.rs
@@ -13,6 +13,9 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 /// Group of base58 encoded cryptographic keys, either secret or public.
 ///

--- a/tezos-core/src/types/encoded/macros.rs
+++ b/tezos-core/src/types/encoded/macros.rs
@@ -124,6 +124,8 @@ macro_rules! make_encoded_struct {
             };
             #[cfg(feature = "serde")]
             use serde::{Deserialize, Serialize};
+            use alloc::string::{ToString, String};
+            use alloc::vec::Vec;
 
             /// Structure representing a base58 encoded Tezos value
             #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tezos-core/src/types/encoded/signature.rs
+++ b/tezos-core/src/types/encoded/signature.rs
@@ -13,6 +13,9 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 /// Group of base58 encoded signatures.
 ///

--- a/tezos-core/src/types/hex_string.rs
+++ b/tezos-core/src/types/hex_string.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::validation::is_hex_str;
 use crate::{Error, Result};
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// Hexadecimal [String] type-safe representation.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tezos-core/src/types/hex_string.rs
+++ b/tezos-core/src/types/hex_string.rs
@@ -1,15 +1,10 @@
 //! Hex String type.
 
-use lazy_static::lazy_static;
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
+use crate::validation::is_hex_str;
 use crate::{Error, Result};
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new("^(0x)?([0-9a-fA-F]{2})*$").unwrap();
-}
 
 /// Hexadecimal [String] type-safe representation.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -62,7 +57,7 @@ impl HexString {
     }
 
     fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_hex_str(value)
     }
 }
 

--- a/tezos-core/src/types/mutez.rs
+++ b/tezos-core/src/types/mutez.rs
@@ -8,22 +8,17 @@ use derive_more::{
     DivAssign, Mul, MulAssign, Not, Octal, Product, Rem, RemAssign, Shl, ShlAssign, Shr, ShrAssign,
     Sub, SubAssign, Sum,
 };
-use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::internal::coder::{ConsumingDecoder, Decoder, Encoder, MutezBytesCoder};
 use crate::internal::consumable_list::ConsumableList;
+use crate::validation::is_uint;
 use crate::{Error, Result};
 
 use super::number::Nat;
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new(r"^[0-9]+$").unwrap();
-}
 
 /// Tezos Mutez type. It can be encoded into and initialized from bytes and many other number
 /// representations.
@@ -85,7 +80,7 @@ pub struct Mutez(#[cfg_attr(feature = "serde", serde(serialize_with = "i64_to_st
 
 impl Mutez {
     pub fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_uint(value)
     }
 
     pub(super) fn value(&self) -> u64 {

--- a/tezos-core/src/types/mutez.rs
+++ b/tezos-core/src/types/mutez.rs
@@ -1,6 +1,6 @@
 //! Tezos Mutez type.
 
-use std::{fmt::Debug, str::FromStr};
+use core::{fmt::Debug, str::FromStr};
 
 use derive_more;
 use derive_more::{
@@ -17,6 +17,9 @@ use crate::internal::coder::{ConsumingDecoder, Decoder, Encoder, MutezBytesCoder
 use crate::internal::consumable_list::ConsumableList;
 use crate::validation::is_uint;
 use crate::{Error, Result};
+use alloc::string::String;
+use alloc::string::ToString;
+use alloc::vec::Vec;
 
 use super::number::Nat;
 

--- a/tezos-core/src/types/number/int.rs
+++ b/tezos-core/src/types/number/int.rs
@@ -1,8 +1,6 @@
-use lazy_static::lazy_static;
 use num_bigint::{BigInt, ToBigInt};
 use num_integer::Integer;
 use num_traits::{Num, ToPrimitive};
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -10,16 +8,13 @@ use std::{
     str::FromStr,
 };
 
+use crate::validation::is_int;
 use crate::{
     internal::coder::{Decoder, Encoder, IntegerBytesCoder},
     Error, Result,
 };
 
 use super::Nat;
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new(r"^-?[0-9]+$").unwrap();
-}
 
 /// An integer that can be encoded to a Zarith number
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -58,7 +53,7 @@ impl Int {
     }
 
     pub fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_int(value)
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>> {

--- a/tezos-core/src/types/number/int.rs
+++ b/tezos-core/src/types/number/int.rs
@@ -1,17 +1,21 @@
+use core::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
 use num_bigint::{BigInt, ToBigInt};
 use num_integer::Integer;
 use num_traits::{Num, ToPrimitive};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    str::FromStr,
-};
 
 use crate::validation::is_int;
 use crate::{
     internal::coder::{Decoder, Encoder, IntegerBytesCoder},
     Error, Result,
+};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
 };
 
 use super::Nat;
@@ -66,7 +70,7 @@ impl Int {
 }
 
 impl Display for Int {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/tezos-core/src/types/number/nat.rs
+++ b/tezos-core/src/types/number/nat.rs
@@ -1,7 +1,5 @@
-use lazy_static::lazy_static;
 use num_bigint::{BigUint, ToBigUint};
 use num_traits::{Num, Unsigned};
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{
@@ -9,6 +7,7 @@ use std::{
     str::FromStr,
 };
 
+use crate::validation::is_uint;
 use crate::{
     internal::{
         coder::{ConsumingDecoder, Decoder, Encoder, NaturalBytesCoder},
@@ -17,10 +16,6 @@ use crate::{
     types::mutez::Mutez,
     Error, Result,
 };
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new(r"^[0-9]+$").unwrap();
-}
 
 /// An unsigned integer that can be encoded to a Zarith number
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -59,7 +54,7 @@ impl Nat {
     }
 
     pub fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_uint(value)
     }
 
     pub fn to_bytes(&self) -> Result<Vec<u8>> {

--- a/tezos-core/src/types/number/nat.rs
+++ b/tezos-core/src/types/number/nat.rs
@@ -1,11 +1,12 @@
+use alloc::string::ToString;
+use core::{
+    fmt::{Debug, Display},
+    str::FromStr,
+};
 use num_bigint::{BigUint, ToBigUint};
 use num_traits::{Num, Unsigned};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Debug, Display},
-    str::FromStr,
-};
 
 use crate::validation::is_uint;
 use crate::{
@@ -16,6 +17,7 @@ use crate::{
     types::mutez::Mutez,
     Error, Result,
 };
+use alloc::{string::String, vec::Vec};
 
 /// An unsigned integer that can be encoded to a Zarith number
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -75,7 +77,7 @@ impl Nat {
 }
 
 impl Display for Nat {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/tezos-core/src/validation.rs
+++ b/tezos-core/src/validation.rs
@@ -1,0 +1,84 @@
+/// Validates that `value` matches Tezos string respecting escaping rules.
+///
+/// TODO: which unescaped special control sequences should be considered invalid?
+/// see https://tezos.gitlab.io/alpha/michelson.html#constants (needs clarification)
+pub fn is_str(value: &str) -> bool {
+    let mut chars = value.chars();
+    !chars.any(|c| match c {
+        ' '..='~' => false,
+        _ => true,
+    })
+}
+
+/// Validates that `value` matches equivalent regex `^(0x)?([0-9a-fA-F]{2})*$`.
+///
+/// TODO: which unescaped special control sequences should be considered invalid?
+/// see https://tezos.gitlab.io/alpha/michelson.html#constants (needs clarification)
+pub fn is_hex_str(value: &str) -> bool {
+    if value.len() % 2 != 0 {
+        return false;
+    }
+    let mut chars = value.chars().peekable();
+    match chars.peek() {
+        Some('0') => {
+            chars.next();
+            match chars.peek() {
+                // once seen a '0', it must be followed by 'x' to build '0x' prefix
+                Some('x') => {
+                    chars.next();
+                }
+                _ => {
+                    // not advancing cursor -> gets validated below
+                }
+            }
+        }
+        _ => {
+            // not advancing cursor -> gets validated below or is an empty string (valid)
+        }
+    }
+    !chars.any(|c| match c {
+        '0'..='9' => false,
+        'A'..='F' => false,
+        'a'..='f' => false,
+        _ => true,
+    })
+}
+
+/// Validates that `value` matches equivalent regex `^-?[0-9]+$`.
+pub fn is_int(value: &str) -> bool {
+    let mut chars = value.chars().peekable();
+    match chars.peek() {
+        None => {
+            // no element!
+            return false;
+        }
+        Some('-') => {
+            chars.next();
+        }
+        _ => {
+            // not advancing cursor -> gets validated below
+        }
+    }
+    !chars.any(|c| match c {
+        '0'..='9' => false,
+        _ => true,
+    })
+}
+
+/// Validates that `value` matches equivalent regex `^[0-9]+$`.
+pub fn is_uint(value: &str) -> bool {
+    let mut chars = value.chars().peekable();
+    match chars.peek() {
+        None => {
+            // empty string is invalid!
+            return false;
+        }
+        _ => {
+            // not advancing cursor -> gets validated below
+        }
+    }
+    !chars.any(|c| match c {
+        '0'..='9' => false,
+        _ => true,
+    })
+}

--- a/tezos-michelson/Cargo.toml
+++ b/tezos-michelson/Cargo.toml
@@ -6,18 +6,22 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-derive_more = "0.99.17"
-num-traits = { version = "0.2", features = ["i128"] }
-num-integer = "0.1"
-hex = "0.4"
+derive_more = { version = "0.99.17", default-features = false }
+num-traits = { version = "0.2", default-features = false }
+num-integer = { version = "0.1", default-features = false }
+hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", features = ["derive"], optional = true }
-chrono = { version = "0.4", features = ["std"], default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
-tezos-core = { path = "../tezos-core" }
+tezos-core = { path = "../tezos-core", version = "0.1.4", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [features]
+default = ["std"]
+std = [
+	"tezos-core/std",
+]
 serde = ["dep:serde", "tezos-core/serde"]

--- a/tezos-michelson/Cargo.toml
+++ b/tezos-michelson/Cargo.toml
@@ -9,11 +9,9 @@ edition = "2021"
 derive_more = "0.99.17"
 num-traits = { version = "0.2", features = ["i128"] }
 num-integer = "0.1"
-regex = "1"
 hex = "0.4"
 serde = { version = "1", features = ["derive"], optional = true }
 chrono = { version = "0.4", features = ["std"], default-features = false }
-lazy_static = "1"
 
 tezos-core = { path = "../tezos-core" }
 

--- a/tezos-michelson/Cargo.toml
+++ b/tezos-michelson/Cargo.toml
@@ -13,7 +13,7 @@ hex = { version = "0.4", default-features = false, features = ["alloc"] }
 serde = { version = "1", features = ["derive"], optional = true }
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 
-tezos-core = { path = "../tezos-core", version = "0.1.4", default-features = false }
+tezos-core = { path = "../tezos-core", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/tezos-michelson/src/common/bytes.rs
+++ b/tezos-michelson/src/common/bytes.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tezos_core::validation::is_hex_str;
 
 use crate::{Error, Result};
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// A structure representing bytes.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/tezos-michelson/src/common/bytes.rs
+++ b/tezos-michelson/src/common/bytes.rs
@@ -1,14 +1,9 @@
 use hex;
-use lazy_static::lazy_static;
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use tezos_core::validation::is_hex_str;
 
 use crate::{Error, Result};
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new("^(0x)?([0-9a-fA-F]{2})*$").unwrap();
-}
 
 /// A structure representing bytes.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -32,7 +27,7 @@ impl Bytes {
 
     /// Returns true if the provided value represents a valid hex string, with or without 0x prefix.
     pub fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_hex_str(value)
     }
 
     pub fn from_string(value: String) -> Result<Self> {

--- a/tezos-michelson/src/common/macros.rs
+++ b/tezos-michelson/src/common/macros.rs
@@ -19,7 +19,7 @@ macro_rules! make_primitive_enum {
             }
         }
 
-        impl std::str::FromStr for Primitive {
+        impl alloc::str::FromStr for Primitive {
             type Err = Error;
 
             fn from_str(s: &str) -> Result<Self> {
@@ -49,7 +49,7 @@ macro_rules! make_primitive_enum {
             }
         }
 
-        impl From<Primitive> for std::string::String {
+        impl From<Primitive> for alloc::string::String {
             fn from(value: Primitive) -> Self {
                 match value {
                     $(Primitive::$name => stringify!($code).into(),)*

--- a/tezos-michelson/src/common/string.rs
+++ b/tezos-michelson/src/common/string.rs
@@ -1,15 +1,10 @@
 use std::str::FromStr;
 
-use lazy_static::lazy_static;
-use regex::Regex;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use tezos_core::validation::is_str;
 
 use crate::{Error, Result};
-
-lazy_static! {
-    static ref REGEX: Regex = Regex::new("^(\"|\r|\n|\t|\\b|\\\\|[^\"\\\\])*$").unwrap();
-}
 
 /// A valid tezos String.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -18,7 +13,7 @@ pub struct String(std::string::String);
 
 impl String {
     pub fn is_valid(value: &str) -> bool {
-        REGEX.is_match(value)
+        is_str(value)
     }
 
     pub fn from_string(value: std::string::String) -> Result<Self> {

--- a/tezos-michelson/src/common/string.rs
+++ b/tezos-michelson/src/common/string.rs
@@ -1,22 +1,23 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use tezos_core::validation::is_str;
 
 use crate::{Error, Result};
+use alloc::borrow::ToOwned;
 
 /// A valid tezos String.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct String(std::string::String);
+pub struct String(alloc::string::String);
 
 impl String {
     pub fn is_valid(value: &str) -> bool {
         is_str(value)
     }
 
-    pub fn from_string(value: std::string::String) -> Result<Self> {
+    pub fn from_string(value: alloc::string::String) -> Result<Self> {
         if Self::is_valid(&value) {
             return Ok(Self(value));
         }
@@ -27,7 +28,7 @@ impl String {
         self.0.as_str()
     }
 
-    pub fn into_string(self) -> std::string::String {
+    pub fn into_string(self) -> alloc::string::String {
         self.0
     }
 }
@@ -40,10 +41,10 @@ impl FromStr for String {
     }
 }
 
-impl TryFrom<std::string::String> for String {
+impl TryFrom<alloc::string::String> for String {
     type Error = Error;
 
-    fn try_from(value: std::string::String) -> Result<Self> {
+    fn try_from(value: alloc::string::String) -> Result<Self> {
         Self::from_string(value)
     }
 }
@@ -56,7 +57,7 @@ impl TryFrom<&str> for String {
     }
 }
 
-impl From<String> for std::string::String {
+impl From<String> for alloc::string::String {
     fn from(value: String) -> Self {
         value.0
     }

--- a/tezos-michelson/src/error.rs
+++ b/tezos-michelson/src/error.rs
@@ -1,5 +1,6 @@
-use std::result;
+use core::result;
 
+use alloc::string::String;
 use derive_more::{Display, From};
 
 #[cfg(feature = "std")]

--- a/tezos-michelson/src/error.rs
+++ b/tezos-michelson/src/error.rs
@@ -1,9 +1,13 @@
 use std::result;
 
-use derive_more::{Display, Error as DError, From};
+use derive_more::{Display, From};
+
+#[cfg(feature = "std")]
+use derive_more::Error as DError;
 
 /// Errors returned by this crate.
-#[derive(DError, Display, Debug, From)]
+#[derive(Display, Debug, From)]
+#[cfg_attr(feature = "std", derive(DError))]
 pub enum Error {
     Internal {
         description: String,

--- a/tezos-michelson/src/internal/coder/micheline_bytes_coder.rs
+++ b/tezos-michelson/src/internal/coder/micheline_bytes_coder.rs
@@ -12,6 +12,9 @@ use crate::{
     michelson::Primitive,
     Error, Result,
 };
+use alloc::borrow::ToOwned;
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub struct MichelineBytesCoder;
 

--- a/tezos-michelson/src/internal/normalizer.rs
+++ b/tezos-michelson/src/internal/normalizer.rs
@@ -12,6 +12,9 @@ use crate::{
         Michelson, PrimType,
     },
 };
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub struct MichelineNormalizer;
 

--- a/tezos-michelson/src/internal/packer.rs
+++ b/tezos-michelson/src/internal/packer.rs
@@ -18,12 +18,15 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::format;
+use alloc::vec;
+use alloc::vec::Vec;
 
 pub trait Packer<T> {
     type Error;
 
-    fn pack(value: T, schema: Option<&Micheline>) -> std::result::Result<Vec<u8>, Error>;
-    fn unpack(bytes: &[u8], schema: Option<&Micheline>) -> std::result::Result<T, Error>;
+    fn pack(value: T, schema: Option<&Micheline>) -> core::result::Result<Vec<u8>, Error>;
+    fn unpack(bytes: &[u8], schema: Option<&Micheline>) -> core::result::Result<T, Error>;
 }
 
 pub struct MichelinePacker;

--- a/tezos-michelson/src/lib.rs
+++ b/tezos-michelson/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! The `tezos-michelson` crate provides various features to make working with `Micheline` expressions easier. It can help developers
 //! to deserialize and serialize expressions from/to JSON, pack and unpack it using an optional schema or convert it to
 //! a better typed `Michelson` structure.
@@ -504,6 +506,7 @@
 //! let micheline: Micheline = pair.into();
 //! let michelson: Michelson = micheline.try_into().expect("valid conversion to Michelson");
 //! ```
+extern crate alloc;
 
 mod common;
 mod error;

--- a/tezos-michelson/src/micheline.rs
+++ b/tezos-michelson/src/micheline.rs
@@ -2,6 +2,7 @@ pub mod literals;
 pub mod primitive_application;
 pub mod sequence;
 mod utils;
+use alloc::vec::Vec;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use tezos_core::internal::{

--- a/tezos-michelson/src/micheline/literals.rs
+++ b/tezos-michelson/src/micheline/literals.rs
@@ -4,6 +4,8 @@ use tezos_core::types::number::Nat;
 
 pub use crate::common::{bytes::Bytes, string::String};
 use crate::{Error, Result};
+use alloc::format;
+use alloc::string::ToString;
 pub use tezos_core::types::number::Int;
 
 use super::Micheline;
@@ -166,10 +168,10 @@ impl From<&String> for Micheline {
     }
 }
 
-impl TryFrom<std::string::String> for Literal {
+impl TryFrom<alloc::string::String> for Literal {
     type Error = Error;
 
-    fn try_from(value: std::string::String) -> Result<Self> {
+    fn try_from(value: alloc::string::String) -> Result<Self> {
         let string: String = value.try_into()?;
 
         Ok(Literal::String(string))

--- a/tezos-michelson/src/micheline/primitive_application.rs
+++ b/tezos-michelson/src/micheline/primitive_application.rs
@@ -4,6 +4,9 @@ use tezos_core::internal::normalizer::Normalizer;
 
 use super::Micheline;
 use crate::{internal::normalizer::MichelineNormalizer, Error, Result};
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// `Micheline` primitive application as defined in [the documentation](https://tezos.gitlab.io/shell/micheline.html#bnf-grammar).
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -85,9 +88,12 @@ impl PrimitiveApplication {
         self
     }
 
-    pub fn try_with_mutated_args<F, Error>(mut self, mutator: F) -> std::result::Result<Self, Error>
+    pub fn try_with_mutated_args<F, Error>(
+        mut self,
+        mutator: F,
+    ) -> core::result::Result<Self, Error>
     where
-        F: FnOnce(Vec<Micheline>) -> std::result::Result<Vec<Micheline>, Error>,
+        F: FnOnce(Vec<Micheline>) -> core::result::Result<Vec<Micheline>, Error>,
     {
         if let Some(args) = self.args {
             self.args = Some(mutator(args)?)
@@ -99,9 +105,9 @@ impl PrimitiveApplication {
         mut self,
         index: usize,
         replacer: F,
-    ) -> std::result::Result<Self, Error>
+    ) -> core::result::Result<Self, Error>
     where
-        F: FnOnce(Micheline) -> std::result::Result<Micheline, Error>,
+        F: FnOnce(Micheline) -> core::result::Result<Micheline, Error>,
     {
         if let Some(args) = self.args.as_mut() {
             let element = args.remove(index);

--- a/tezos-michelson/src/micheline/sequence.rs
+++ b/tezos-michelson/src/micheline/sequence.rs
@@ -9,6 +9,8 @@ use crate::{
     },
     Error, Result,
 };
+use alloc::format;
+use alloc::vec::Vec;
 
 /// `Micheline` sequence types as defined in [the documentation](https://tezos.gitlab.io/shell/micheline.html#bnf-grammar).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tezos-michelson/src/micheline/utils.rs
+++ b/tezos-michelson/src/micheline/utils.rs
@@ -3,6 +3,7 @@ use crate::micheline::{
     literals::{Bytes, Int, String},
     PrimitiveApplication,
 };
+use alloc::vec::Vec;
 
 /// Utility function to create a tezos [String] and convert it to
 /// a type inferred by the context at call location.
@@ -18,9 +19,9 @@ use crate::micheline::{
 ///     Ok(())
 /// }
 /// ```
-pub fn try_string<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_string<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<String, Error = Error>,
+    T: core::convert::TryInto<String, Error = Error>,
     Output: From<String>,
 {
     let string: String = value.try_into()?;
@@ -39,7 +40,7 @@ where
 /// ```
 pub fn int<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<Int>,
+    T: core::convert::Into<Int>,
     Output: From<Int>,
 {
     let int: Int = value.into();
@@ -60,9 +61,9 @@ where
 ///     Ok(())
 /// }
 /// ```
-pub fn try_int<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_int<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<Int, Error = Error>,
+    T: core::convert::TryInto<Int, Error = Error>,
     Output: From<Int>,
 {
     let int: Int = value.try_into()?;
@@ -81,7 +82,7 @@ where
 /// ```
 pub fn bytes<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<Bytes>,
+    T: core::convert::Into<Bytes>,
     Output: From<Bytes>,
 {
     let bytes: Bytes = value.into();
@@ -102,9 +103,9 @@ where
 ///     Ok(())
 /// }
 /// ```
-pub fn try_bytes<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_bytes<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<Bytes, Error = Error>,
+    T: core::convert::TryInto<Bytes, Error = Error>,
     Output: From<Bytes>,
 {
     let bytes: Bytes = value.try_into()?;
@@ -120,7 +121,7 @@ where
 /// ```
 pub fn primitive_application<T>(prim: T) -> PrimitiveApplication
 where
-    T: std::convert::Into<std::string::String>,
+    T: core::convert::Into<alloc::string::String>,
 {
     PrimitiveApplication::new(prim.into(), None, None)
 }
@@ -135,7 +136,7 @@ where
 /// let value: Micheline = sequence(vec![int(10), bytes(vec![10u8])]);
 pub fn sequence<T, Output>(values: T) -> Output
 where
-    T: std::convert::Into<Vec<Micheline>>,
+    T: core::convert::Into<Vec<Micheline>>,
     Output: From<Sequence>,
 {
     let values: Vec<Micheline> = values.into();

--- a/tezos-michelson/src/michelson.rs
+++ b/tezos-michelson/src/michelson.rs
@@ -82,7 +82,7 @@ impl Michelson {
     /// use tezos_michelson::michelson::{data, Michelson, types};
     /// use hex_literal::hex;
     ///
-    /// let michelson = Michelson::unpack(&bytes, Some(&types::int()));
+    /// let michelson = Michelson::unpack(&hex!("A3"), Some(&types::int()));
     /// ```
     pub fn unpack(bytes: &[u8], schema: Option<&Type>) -> Result<Self> {
         let schema: Option<Micheline> = schema.map(|value| value.into());

--- a/tezos-michelson/src/michelson.rs
+++ b/tezos-michelson/src/michelson.rs
@@ -3,8 +3,12 @@ pub mod data;
 pub mod metadata;
 pub mod types;
 
+use alloc::format;
+use alloc::str::FromStr;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 use annotations::Annotation;
-use std::str::FromStr;
 use tezos_core::internal::normalizer::Normalizer;
 
 pub use self::{

--- a/tezos-michelson/src/michelson.rs
+++ b/tezos-michelson/src/michelson.rs
@@ -78,7 +78,6 @@ impl Michelson {
     /// use tezos_michelson::michelson::{data, Michelson, types};
     /// use hex_literal::hex;
     ///
-    /// let bytes = hex!("05002a");
     /// let michelson = Michelson::unpack(&bytes, Some(&types::int()));
     /// ```
     pub fn unpack(bytes: &[u8], schema: Option<&Type>) -> Result<Self> {

--- a/tezos-michelson/src/michelson/annotations.rs
+++ b/tezos-michelson/src/michelson/annotations.rs
@@ -1,4 +1,6 @@
 use crate::{Error, Result};
+use alloc::format;
+use alloc::string::String;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Kind {

--- a/tezos-michelson/src/michelson/data.rs
+++ b/tezos-michelson/src/michelson/data.rs
@@ -11,6 +11,8 @@ pub use sequence::{sequence, Sequence};
 use tezos_core::internal::normalizer::Normalizer;
 pub use tezos_core::types::number::{Int, Nat};
 
+use alloc::vec::Vec;
+
 make_all_data!(
     custom_cases: {
         Int(Int),
@@ -69,10 +71,10 @@ impl From<i8> for Data {
     }
 }
 
-impl TryFrom<std::string::String> for Data {
+impl TryFrom<alloc::string::String> for Data {
     type Error = Error;
 
-    fn try_from(value: std::string::String) -> Result<Self> {
+    fn try_from(value: alloc::string::String) -> Result<Self> {
         let value: String = value.try_into()?;
         Ok(value.into())
     }
@@ -289,16 +291,16 @@ impl From<Primitive> for crate::michelson::Primitive {
 
 pub fn int<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<Int>,
+    T: core::convert::Into<Int>,
     Output: From<Int>,
 {
     let value: Int = value.into();
     value.into()
 }
 
-pub fn try_int<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_int<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<Int, Error = Error>,
+    T: core::convert::TryInto<Int, Error = Error>,
     Output: From<Int>,
 {
     let value: Int = value.try_into()?;
@@ -307,16 +309,16 @@ where
 
 pub fn nat<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<Nat>,
+    T: core::convert::Into<Nat>,
     Output: From<Nat>,
 {
     let value: Nat = value.into();
     value.into()
 }
 
-pub fn try_nat<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_nat<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<Nat, Error = Error>,
+    T: core::convert::TryInto<Nat, Error = Error>,
     Output: From<Nat>,
 {
     let value: Nat = value.try_into()?;
@@ -325,16 +327,16 @@ where
 
 pub fn string<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<String>,
+    T: core::convert::Into<String>,
     Output: From<String>,
 {
     let value: String = value.into();
     value.into()
 }
 
-pub fn try_string<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_string<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<String, Error = Error>,
+    T: core::convert::TryInto<String, Error = Error>,
     Output: From<String>,
 {
     let value: String = value.try_into()?;
@@ -343,16 +345,16 @@ where
 
 pub fn bytes<T, Output>(value: T) -> Output
 where
-    T: std::convert::Into<Bytes>,
+    T: core::convert::Into<Bytes>,
     Output: From<Bytes>,
 {
     let value: Bytes = value.into();
     value.into()
 }
 
-pub fn try_bytes<T, Output, Error>(value: T) -> std::result::Result<Output, Error>
+pub fn try_bytes<T, Output, Error>(value: T) -> core::result::Result<Output, Error>
 where
-    T: std::convert::TryInto<Bytes, Error = Error>,
+    T: core::convert::TryInto<Bytes, Error = Error>,
     Output: From<Bytes>,
 {
     let value: Bytes = value.try_into()?;

--- a/tezos-michelson/src/michelson/data/instructions/macros.rs
+++ b/tezos-michelson/src/michelson/data/instructions/macros.rs
@@ -113,6 +113,11 @@ macro_rules! make_instruction {
                 micheline::{Micheline, primitive_application::PrimitiveApplication},
                 Error, Result,
             };
+            use alloc::string::String;
+            use alloc::vec::Vec;
+            use alloc::vec;
+            #[allow(unused_imports)]
+            use alloc::boxed::Box;
 
             #[derive(Debug, Clone, PartialEq)]
             pub struct $name {

--- a/tezos-michelson/src/michelson/data/instructions/sequence.rs
+++ b/tezos-michelson/src/michelson/data/instructions/sequence.rs
@@ -4,6 +4,7 @@ use crate::{
     michelson::{data::Data, Michelson},
     Error, Result,
 };
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Sequence(Vec<Instruction>);

--- a/tezos-michelson/src/michelson/data/macros.rs
+++ b/tezos-michelson/src/michelson/data/macros.rs
@@ -157,6 +157,9 @@ macro_rules! make_data {
                 Error, Result,
             };
             use super::{Data, Primitive};
+            #[allow(unused_imports)]
+            use alloc::vec::Vec;
+            use alloc::vec;
 
             #[derive(Debug, Clone, PartialEq)]
             pub struct $name;
@@ -260,6 +263,10 @@ macro_rules! make_data {
                 micheline::{Micheline, primitive_application::PrimitiveApplication},
                 Error, Result,
             };
+            use alloc::vec::Vec;
+            use alloc::vec;
+            #[allow(unused_imports)]
+            use alloc::boxed::Box;
 
             #[derive(Debug, Clone, PartialEq)]
             pub struct $name {

--- a/tezos-michelson/src/michelson/data/map.rs
+++ b/tezos-michelson/src/michelson/data/map.rs
@@ -1,6 +1,7 @@
 use crate::{micheline::Micheline, michelson::Michelson, Error, Result};
 
 use super::{Data, Elt};
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Map(Vec<Elt>);

--- a/tezos-michelson/src/michelson/data/sequence.rs
+++ b/tezos-michelson/src/michelson/data/sequence.rs
@@ -4,6 +4,7 @@ use crate::{
     michelson::Michelson,
     Error, Result,
 };
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Sequence(Vec<Data>);

--- a/tezos-michelson/src/michelson/metadata.rs
+++ b/tezos-michelson/src/michelson/metadata.rs
@@ -1,5 +1,8 @@
 use super::annotations::{Annotation, Kind};
 use crate::{micheline::primitive_application::PrimitiveApplication, Error, Result};
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldMetadata {

--- a/tezos-michelson/src/michelson/types/macros.rs
+++ b/tezos-michelson/src/michelson/types/macros.rs
@@ -135,6 +135,10 @@ macro_rules! make_type {
                 Error, Result,
             };
             use super::{Type, Primitive};
+            use alloc::vec::Vec;
+            use alloc::vec;
+            #[allow(unused_imports)]
+            use alloc::boxed::Box;
 
             #[derive(Debug, Clone, PartialEq)]
             pub struct $name {
@@ -168,13 +172,13 @@ macro_rules! make_type {
                     }
                 }
 
-                pub fn with_type_annotation<Output>(mut self, annotation: std::string::String) -> Output where Output: From<$name> {
+                pub fn with_type_annotation<Output>(mut self, annotation: alloc::string::String) -> Output where Output: From<$name> {
                     self.metadata = self.metadata.with_type_name(annotation);
 
                     self.into()
                 }
 
-                pub fn with_field_annotation<Output>(mut self, annotation: std::string::String) -> Output where Output: From<$name> {
+                pub fn with_field_annotation<Output>(mut self, annotation: alloc::string::String) -> Output where Output: From<$name> {
                     self.metadata = self.metadata.with_field_name(annotation);
 
                     self.into()
@@ -268,7 +272,7 @@ macro_rules! make_type {
                 #[allow(unused)]
                 fn from(value: $name) -> Self {
                     let mut args: Vec<Micheline> = vec![];
-                    let annots: Vec<std::string::String> = value.annotations().into_iter().map(|annot| annot.value().into()).collect();
+                    let annots: Vec<alloc::string::String> = value.annotations().into_iter().map(|annot| annot.value().into()).collect();
                     $(
                         args.push(value.$field_name.into());
                     )*
@@ -289,7 +293,7 @@ macro_rules! make_type {
                 #[allow(unused)]
                 fn from(value: &$name) -> Self {
                     let mut args: Vec<Micheline> = vec![];
-                    let annots: Vec<std::string::String> = value.annotations().into_iter().map(|annot| annot.value().into()).collect();
+                    let annots: Vec<alloc::string::String> = value.annotations().into_iter().map(|annot| annot.value().into()).collect();
                     $(
                         args.push((&value.$field_name).into());
                     )*

--- a/tezos-operation/Cargo.toml
+++ b/tezos-operation/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 chrono = { version= "0.4", default-features = false, features = ["clock", "std"] }
 derive_more = "0.99.17"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3"
 hex = "0.4"
 

--- a/tezos-operation/Cargo.toml
+++ b/tezos-operation/Cargo.toml
@@ -10,8 +10,8 @@ num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3"
 hex = "0.4"
 
-tezos-core = { path = "../tezos-core" }
-tezos-michelson = { path = "../tezos-michelson" }
+tezos-core = { path = "../tezos-core", version = "0.1.4" }
+tezos-michelson = { path = "../tezos-michelson", version = "0.1.4" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/tezos-operation/Cargo.toml
+++ b/tezos-operation/Cargo.toml
@@ -10,8 +10,8 @@ num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3"
 hex = "0.4"
 
-tezos-core = { path = "../tezos-core", version = "0.1.4" }
-tezos-michelson = { path = "../tezos-michelson", version = "0.1.4" }
+tezos-core = { path = "../tezos-core" }
+tezos-michelson = { path = "../tezos-michelson" }
 
 [dev-dependencies]
 hex-literal = "0.3"

--- a/tezos-operation/src/error.rs
+++ b/tezos-operation/src/error.rs
@@ -1,8 +1,11 @@
 use std::string::FromUtf8Error;
 
-use derive_more::{Display, Error as DError, From};
+#[cfg(feature = "std")]
+use derive_more::Error as DError;
+use derive_more::{Display, From};
 
-#[derive(DError, Display, Debug, From)]
+#[derive(Display, Debug, From)]
+#[cfg_attr(feature = "std", derive(DError))]
 pub enum Error {
     Core { source: tezos_core::Error },
     Michelson { source: tezos_michelson::Error },

--- a/tezos-rpc/Cargo.toml
+++ b/tezos-rpc/Cargo.toml
@@ -15,9 +15,9 @@ chrono = { version = "0.4",  features = ["serde", "std"], default-features = fal
 async-trait = "0.1"
 
 # Local dependencies
-tezos-core = { path = "../tezos-core", features = ["serde"] }
-tezos-michelson = { path = "../tezos-michelson", features = ["serde"] }
-tezos-operation = { path = "../tezos-operation" }
+tezos-core = { path = "../tezos-core", version = "0.1.4", features = ["serde"] }
+tezos-michelson = { path = "../tezos-michelson", version = "0.1.4", features = ["serde"] }
+tezos-operation = { path = "../tezos-operation", version = "0.1.4" }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["macros"] }

--- a/tezos-rpc/Cargo.toml
+++ b/tezos-rpc/Cargo.toml
@@ -15,9 +15,9 @@ chrono = { version = "0.4",  features = ["serde", "std"], default-features = fal
 async-trait = "0.1"
 
 # Local dependencies
-tezos-core = { path = "../tezos-core", version = "0.1.4", features = ["serde"] }
-tezos-michelson = { path = "../tezos-michelson", version = "0.1.4", features = ["serde"] }
-tezos-operation = { path = "../tezos-operation", version = "0.1.4" }
+tezos-core = { path = "../tezos-core", features = ["serde"] }
+tezos-michelson = { path = "../tezos-michelson", features = ["serde"] }
+tezos-operation = { path = "../tezos-operation" }
 
 [dev-dependencies]
 tokio = { version = "1.19", features = ["macros"] }

--- a/tezos-rpc/src/error.rs
+++ b/tezos-rpc/src/error.rs
@@ -1,9 +1,12 @@
+#[cfg(feature = "std")]
+use derive_more::Error as DError;
 use {
     crate::models::error::RpcErrors,
-    derive_more::{Display, Error, From},
+    derive_more::{Display, From},
 };
 
-#[derive(Debug, From, Display, Error)]
+#[derive(Debug, From, Display)]
+#[cfg_attr(feature = "std", derive(DError))]
 pub enum Error {
     Core {
         source: tezos_core::Error,
@@ -27,7 +30,7 @@ pub enum Error {
     RpcErrorPlain {
         description: String,
     },
-    RpcErrors(#[error(not(source))] RpcErrors),
+    RpcErrors(#[cfg_attr(feature = "std", error(not(source)))] RpcErrors),
     InvalidConversion,
     OperationNotSupported,
 }


### PR DESCRIPTION
no_std compatible
- [x] `tezos-core`
- [x] `tezos-michelson`